### PR TITLE
Better middleware

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -25,11 +25,12 @@ import (
 )
 
 type Config struct {
-	Logger         *logrus.Entry
-	HealthHandler  echo.HandlerFunc
-	CorsOrigins    []string
-	HealthResponse map[string]interface{}
-	StatusResponse map[string]interface{}
+	Logger                 *logrus.Entry
+	LoggingMiddlwareConfig LoggingMiddlwareConfig
+	HealthHandler          echo.HandlerFunc
+	CorsOrigins            []string
+	HealthResponse         map[string]interface{}
+	StatusResponse         map[string]interface{}
 }
 
 func New(cfg Config) *echo.Echo {
@@ -54,7 +55,7 @@ func New(cfg Config) *echo.Echo {
 	e.Logger.SetOutput(os.Stdout)
 	e.HideBanner = true
 	e.HTTPErrorHandler = NewHTTPErrorHandler(e)
-	e.Use(LoggingMiddleware(cfg.Logger))
+	e.Use(LoggingMiddlewareWithConfig(cfg.Logger, cfg.LoggingMiddlwareConfig))
 	if cfg.CorsOrigins != nil {
 		e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
 			AllowOrigins:     cfg.CorsOrigins,

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -152,6 +152,52 @@ var _ = Describe("API", func() {
 			Expect(logHook.Entries).To(HaveLen(1))
 			Expect(logHook.Entries[0].Level).To(Equal(logrus.DebugLevel))
 		})
+		It("can log request and response headers", func() {
+			e = api.New(api.Config{
+				Logger: logEntry,
+				LoggingMiddlwareConfig: api.LoggingMiddlwareConfig{
+					RequestHeaders:  true,
+					ResponseHeaders: true,
+				},
+			})
+			e.GET("/", func(c echo.Context) error {
+				c.Response().Header().Set("ResHead", "ResHeadVal")
+				return c.String(200, "ok")
+			})
+			Expect(Serve(e, GetRequest("/", SetReqHeader("ReqHead", "ReqHeadVal")))).To(HaveResponseCode(200))
+			Expect(logHook.Entries).To(HaveLen(1))
+			Expect(logHook.Entries[0].Data).To(And(
+				HaveKeyWithValue("request_header.Reqhead", "ReqHeadVal"),
+				HaveKeyWithValue("response_header.Reshead", "ResHeadVal"),
+			))
+		})
+		It("can use custom DoLog, BeforeRequest, and AfterRequest hooks", func() {
+			doLogCalled := false
+			e = api.New(api.Config{
+				Logger: logEntry,
+				LoggingMiddlwareConfig: api.LoggingMiddlwareConfig{
+					BeforeRequest: func(_ echo.Context, e *logrus.Entry) *logrus.Entry {
+						return e.WithField("before", 1)
+					},
+					AfterRequest: func(_ echo.Context, e *logrus.Entry) *logrus.Entry {
+						return e.WithField("after", 2)
+					},
+					DoLog: func(c echo.Context, e *logrus.Entry) {
+						doLogCalled = true
+						api.LoggingMiddlewareDefaultDoLog(c, e)
+					},
+				},
+			})
+			e.GET("/", func(c echo.Context) error {
+				return c.String(400, "")
+			})
+			Expect(Serve(e, GetRequest("/"))).To(HaveResponseCode(400))
+			Expect(doLogCalled).To(BeTrue())
+			Expect(logHook.Entries[len(logHook.Entries)-1].Data).To(And(
+				HaveKeyWithValue("before", 1),
+				HaveKeyWithValue("after", 2),
+			))
+		})
 	})
 
 	Describe("error handling", func() {

--- a/logctx/logctx.go
+++ b/logctx/logctx.go
@@ -67,6 +67,8 @@ func Logger(c context.Context) *logrus.Entry {
 	return logger
 }
 
+// ActiveTraceId returns the first valid trace value and type from the given context,
+// or MissingTraceIdKey if there is none.
 func ActiveTraceId(c context.Context) (TraceIdKey, string) {
 	if trace, ok := c.Value(RequestTraceIdKey).(string); ok {
 		return RequestTraceIdKey, trace
@@ -78,6 +80,12 @@ func ActiveTraceId(c context.Context) (TraceIdKey, string) {
 		return ProcessTraceIdKey, trace
 	}
 	return MissingTraceIdKey, "no-trace-id-in-context"
+}
+
+// ActiveTraceIdValue returns the value part of ActiveTraceId (does not return the TradeIdKey type part).
+func ActiveTraceIdValue(c context.Context) string {
+	_, v := ActiveTraceId(c)
+	return v
 }
 
 func AddFieldsAndGet(c context.Context, fields map[string]interface{}) (context.Context, *logrus.Entry) {

--- a/logctx/logctx_test.go
+++ b/logctx/logctx_test.go
@@ -30,6 +30,7 @@ var _ = Describe("logtools", func() {
 			key, val := logctx.ActiveTraceId(c)
 			Expect(key).To(Equal(logctx.RequestTraceIdKey))
 			Expect(val).To(Equal("abc"))
+			Expect(logctx.ActiveTraceIdValue(c)).To(Equal("abc"))
 		})
 		It("returns a process trace id", func() {
 			c := context.WithValue(bg, logctx.ProcessTraceIdKey, "abc")

--- a/parallel/parallel_test.go
+++ b/parallel/parallel_test.go
@@ -37,4 +37,8 @@ var _ = Describe("ParallelFor", func() {
 		Expect(called).To(Equal(1000))
 		Expect(active).To(Equal(0))
 	})
+	It("errors for 0 or negative n", func() {
+		err := parallel.ForEach(1, 0, nil)
+		Expect(err).To(BeIdenticalTo(parallel.ErrInvalidParallelism))
+	})
 })


### PR DESCRIPTION
Add support for dumping memory stats when running under debug

---

Validate negative parallelism, it would be bad.

---

Add logctx.ActiveTraceIdValue, when you want just the value

---

Add configuration support to LoggingMiddleware