### PR TITLE
Support more logging configuration

### DIFF
--- a/api/logging.go
+++ b/api/logging.go
@@ -115,7 +115,7 @@ func LoggingMiddlewareWithConfig(outerLogger *slog.Logger, cfg LoggingMiddlwareC
 			if err != nil {
 				logger = logger.With("request_error", err)
 			}
-			if cfg.BeforeRequest != nil {
+			if cfg.AfterRequest != nil {
 				logger = cfg.AfterRequest(c, logger)
 			}
 			cfg.DoLog(c, logger)

--- a/api/trace_id.go
+++ b/api/trace_id.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/lithictech/go-aperitif/v2/logctx"
 )
@@ -39,7 +38,7 @@ func TraceId(c echo.Context) string {
 		}
 	}
 
-	newId := uuid.New().String()
+	newId := logctx.IdProvider()
 	c.Set(traceIdKey, newId)
 	c.Response().Header().Set(TraceIdHeader, newId)
 	return newId

--- a/logctx/log_hook.go
+++ b/logctx/log_hook.go
@@ -34,7 +34,12 @@ func (t *Hook) Enabled(context.Context, slog.Level) bool {
 }
 
 func (t *Hook) Handle(_ context.Context, r slog.Record) error {
-	t.records.Add(HookRecord{Record: r, Attrs: t.attrs, Group: t.group})
+	attrs := t.attrs
+	r.Attrs(func(a slog.Attr) bool {
+		attrs = append(attrs, a)
+		return true
+	})
+	t.records.Add(HookRecord{Record: r, Attrs: attrs, Group: t.group})
 	return nil
 }
 

--- a/logctx/tracing_handler.go
+++ b/logctx/tracing_handler.go
@@ -1,0 +1,56 @@
+package logctx
+
+import (
+	"context"
+	"log/slog"
+)
+
+func NewTracingHandler(h slog.Handler) slog.Handler {
+	return &TracingHandler{
+		h:             h,
+		TraceIdLogKey: "trace_id",
+		SpanIdLogKey:  "span_id",
+		GetTraceId: func(ctx context.Context) any {
+			k, t := ActiveTraceId(ctx)
+			if k == MissingTraceIdKey {
+				return nil
+			}
+			return t
+		},
+		GetSpanId: func(ctx context.Context) any {
+			return ctx.Value(SpanIdKey)
+		},
+	}
+}
+
+type TracingHandler struct {
+	h             slog.Handler
+	TraceIdLogKey string
+	SpanIdLogKey  string
+	GetTraceId    func(context.Context) any
+	GetSpanId     func(context.Context) any
+}
+
+func (t *TracingHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return t.h.Enabled(ctx, level)
+}
+
+func (t *TracingHandler) Handle(ctx context.Context, record slog.Record) error {
+	if tid := t.GetTraceId(ctx); tid != nil {
+		record.Add(t.TraceIdLogKey, tid)
+	}
+	if sid := t.GetSpanId(ctx); sid != nil {
+		record.Add(t.SpanIdLogKey, sid)
+	}
+	return t.h.Handle(ctx, record)
+}
+
+func (t *TracingHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return NewTracingHandler(t.h.WithAttrs(attrs))
+}
+
+func (t *TracingHandler) WithGroup(name string) slog.Handler {
+	return NewTracingHandler(t.h.WithGroup(name))
+}
+
+var _ slog.Handler = &TracingHandler{}


### PR DESCRIPTION
- Add a custom ID provider rather than always using uuid4
- Add a MakeHandler to allow callers to override the
  log handler.
- Add TracingHandler, which provides an easy log handler
  that can log out trace and span ids.

---

Fix typo in logging middleware
